### PR TITLE
Reworked fillHand

### DIFF
--- a/lib/3CardConverter.js
+++ b/lib/3CardConverter.js
@@ -55,51 +55,42 @@ module.exports = {
     "ah": 51,
     "as": 52
   },
+  makesStraight: function(cardsUsed, rank) {
+    //add ace to bottom as well
+    var newCards = [cardsUsed[12]].concat(cardsUsed);
+    //add in new card (pushed up one by ace)
+    newCards[rank+1] = 2;
+    //determine if there are 5 cards in a row
+    return 5 === newCards.reduce(function(prev, next) {
+      if (prev === 5) {
+        return 5;
+      } else {
+        return next ? prev + 1 : 0;
+      }
+    });
+  },
 
   fillHand: function(cards) {
 
   	var cardsUsed = [0,0,0,0,0,0,0,0,0,0,0,0,0];
+
   	//convert each card to vals 0-12, strip suit
   	cards.forEach(function(card) {
-  		var i = Math.floor(this.CARDS[card.toLowerCase()]/4);
+  		var i = Math.floor((this.CARDS[card.toLowerCase()]-1)/4);
   		cardsUsed[i] = 1;
   	}, this);
 
   	var toFill = 2; //need to fill 2 cards
-  	var maxFillIndex = 0; //index in cardsUsed of highest filled card
 
     //fill in <toFill> cards to complete 5 card hand
   	for (var i = 0; i < 13; i++) {
   	  if (toFill == 0) break; //done filling
-      if (cardsUsed[i] == 0) {
+      //prevent adding a card to finish a straight
+      if (cardsUsed[i] == 0 && !this.makesStraight(cardsUsed,i)) {
         cardsUsed[i] = 2;
-        maxFillIndex = i;
         toFill--;
       }
   	}
-
-    //check if there is straight
-    var continuousCards = 0;
-    var hasStraight = false;
-    var straightEndIndex = 0;
-
-    for (var i = 0; i <= 13; i++) {
-      if (cardsUsed[i] == 0) {
-        continuousCards = 0;
-      } else {
-        continuousCards++;
-        if (continuousCards == 5) {
-          hasStraight = true;
-          straightEndIndex = i;
-        }
-      }
-    }
-
-    //if there is straight, fix it by shifting highest filled card to one past the straight
-    if (hasStraight) {
-      cardsUsed[maxFillIndex] = 0;
-      cardsUsed[straightEndIndex + 1] = 2;
-    }
 
     //fill dummy cards for lowest possible hand
     var suit = ['s', 'd'];
@@ -110,7 +101,6 @@ module.exports = {
         cards.push(card);
       }
     }
-
     return cards;
   }
 };


### PR DESCRIPTION
I've changed the way the fillHand checks for straights to make a fix for Ace-low straights, as well as a small fix to the ranking of cards (spades were up-ranked).

maintains lowest ranked 5-card hand for ofcp compares
