### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-#Poker Hand Evaluator
+# Poker Hand Evaluator
 
 Poker hand evaluator using the Two Plus Two alogorithm and lookup table.
 The lookup table HandRanks.dat is included in the module.
@@ -9,11 +9,11 @@ Hands can be evaluated by comparing the handType then the handRank to determine 
 
 This can evaluate about 22MM hands per second on a quad-core 2.7GHz Macbook Pro.  Run the speedtest.js file under /test to try it.
 
-##to install:
+## to install:
 
 npm install poker-evaluator
 
-##Usage:
+## Usage:
 
 ```js
 var PokerEvaluator = require("poker-evaluator");


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
